### PR TITLE
[FEAT] Gateway Server URI 변경 및 로컬/EC2 환경 설정 업데이트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,8 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-gateway-server-webflux'
 	implementation 'org.springframework.cloud:spring-cloud-starter-loadbalancer'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    // actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'io.projectreactor:reactor-test'

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,9 +8,8 @@ spring:
     import: 'optional:configserver:'
   cloud:
     config:
-      discovery:
-        enabled: true
-        service-id: config-server
+      uri: http://3.38.80.105:9100
+      fail-fast: true # Config Server 연결 실패 시 애플리케이션을 즉시 종료
 
 eureka:
   instance:
@@ -21,4 +20,4 @@ eureka:
     register-with-eureka: true
     fetch-registry: true # 클라이언트 사이드 로드밸런싱을 위해, 유레카 정보를 다운 받는다.
     service-url:
-      defaultZone: http://localhost:9150/eureka/
+      defaultZone: http://3.38.80.105:9150/eureka/


### PR DESCRIPTION
## 🛠️ 작업 내용 (Details)
 - Gateway server를 위한 HTTPS기반 외부 접근 환경 구성
 - EC2에 설치된 nginx를 활용한 HTTP -> HTTPS 리다이렉션 설정
 - api.athenhub.xyz 도메인에 대해
   - nginx -> Gateway server로 reverse proxy 연결
 - Gateway 헬스 체크가 EC2 외부에서도 HTTPS 기반으로 정상 응답 되도록 설정



## 🔀 변경 유형 (Change Type)
아래 항목 중 해당하는 부분에 체크(✔) 해주세요.

- [x] 새로운 기능 추가  
- [ ] 버그 수정  
- [ ] 코드 스타일 업데이트 (formatting, renaming)  
- [ ] 코드 리팩토링  
- [x] 문서 수정  
- [x] 기타 (설명 필요)  
- [ ] 성능 개선  
- [ ] 파괴적인 변경 (breaking change)


## 🧪 테스트 방법 (Testing)
 - EC2 내부
   - curl -v http://localhost:9000/actuator/health
 - 외부 환경(로컬 mac)
   - curl -v https://api.athenhub.xyz/actuator/health
 - 브라우저
   - https://api.athenhub.xyz

